### PR TITLE
Reorder Gradle plugins to remove a warning

### DIFF
--- a/bubbletabbar/build.gradle
+++ b/bubbletabbar/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 ext {
     PUBLISH_GROUP_ID = 'com.fxn769'
     PUBLISH_ARTIFACT_ID = 'bubbletabbar'


### PR DESCRIPTION
Gradle sync produces this warning:

```
> Configure project :bubbletabbar
Kotlin plugin should be enabled before 'kotlin-android-extensions'
```
Android Studio 3.5.3, Gradle 5.4.1